### PR TITLE
Make MODULESPATH manipulation idempotent

### DIFF
--- a/templates/modules-cvmfs.csh
+++ b/templates/modules-cvmfs.csh
@@ -5,5 +5,28 @@ if ( -f "/etc/profile.d/modules.csh" ) then
 endif
 
 #setenv MODULEPATH "${MODULEPATH}:/cvmfs/fgi.csc.fi/modules/el7/all"
-setenv MODULEPATH "${MODULEPATH}:{{ bash_modules_path }}"
+#setenv MODULEPATH "${MODULEPATH}:{{ bash_modules_path }}"
 
+set _modpaths__fgci = `echo {{ bash_modules_path }} | sed 's/:/ /g'`
+
+# For reasoning of this, see modules-cvmfs.sh
+
+# Someone who is a csh expert: feel free to rewrite this.
+
+if ( ${?_modpaths__fgci} ) then
+    foreach _modpath__fgci ($_modpaths__fgci:q)
+	if ( ! ${?MODULEPATH} ) then
+	    setenv MODULEPATH $_modpath__fgci:q
+	else if ( "$MODULEPATH:q" == '' ) then
+	    setenv MODULEPATH $_modpath__fgci:q
+	else if (  "$MODULEPATH:q" =~ "${_modpath__fgci:q}" \
+		|| "$MODULEPATH:q" =~ "*:${_modpath__fgci:q}" \
+		|| "$MODULEPATH:q" =~ "${_modpath__fgci:q}:*" \
+		|| "$MODULEPATH:q" =~ "*:${_modpath__fgci:q}:*" ) then
+	else
+	    setenv MODULEPATH "${MODULEPATH:q}:${_modpath__fgci:q}"
+	endif
+    end
+endif
+
+unset _modpath__fgci _modpaths__fgci

--- a/templates/modules-cvmfs.sh
+++ b/templates/modules-cvmfs.sh
@@ -4,5 +4,29 @@ if [ -f /etc/profile.d/modules.sh ] ; then
  . /etc/profile.d/modules.sh
 fi
 #export MODULEPATH=$MODULEPATH:/cvmfs/fgi.csc.fi/modules/el7/all
-export MODULEPATH=$MODULEPATH:{{ bash_modules_path }}
+#export MODULEPATH=$MODULEPATH:{{ bash_modules_path }}
 
+# Idempotently add each of the paths to the module paths.  It is
+# critical to blindly append to MODULEPATH if re-loaded, because: 1)
+# lmod will complain that the path has change, 2) subshells will
+# re-read this file, including slurm scripts, and 3) save/restore of
+# modules doesn't work.
+
+# function to idempotently append anything to any PATH-like variable
+PATHADD2 () { if eval [ x"\"\$$1\"" = x'' ] ; then eval "export $1=$2" ; else eval "echo \"\$$1\"" | grep "\(^\|:\)$2\(:\|$\)" 2>&1 > /dev/null || eval "export $1=\$$1:$2" ; fi }
+
+# this is a bashism (-a):
+#IFS=: read -ra _paths__fgciload <<< {{ bash_modules_path }}
+#for _path__fgciload in "${paths[@]}"; do
+#    PATHADD2 MODULEPATH "$path"
+#done
+
+_modules__fgci="{{ bash_modules_path }}"
+while [ _modules__fgci ] ; do
+    _mod__fgci=${_modules__fgci%%:*}
+    PATHADD2 MODULEPATH "$_mod__fgci"
+    [ "$_modules__fgci" = "$_mod__fgci" ] && break || _modules__fgci=${_modules__fgci#*:}
+done
+
+unset _path__fgciload _paths__fgciload
+unset -f PATHADD2


### PR DESCRIPTION
This makes MODULESPATH changes idempotent (#5), and I *think* now handles all cases, excepts paths with spaces in them in csh.  I've deployed this at Aalto and it seems to work.  This is needed so that subshells (tmux, screen, slurm scripts) can save/restore modules.

This only solves the specific case of this file blindly appending.  If other local scripts do, it might be good to leave the bash shell function defined so that other scripts can use it (and do similar things for csh, but it has no functions so this is harder), but that is a task for another time.  Csh is ugly because there aren't functions, so everything has to be hard-coded.

Tested with: bash, tcsh, zsh, sh(bash), bash --posix.

Steps to reproduce problem without this:
```
module 
bash -l
module
```

I checked CSC's solution for reference, and they set a variable that tells not to reset the paths.  I already had my bash appending function, so I improved that and did same for csh.
