### PR TITLE
Check that the man command exists before using it

### DIFF
--- a/files/fgi-manpath.csh
+++ b/files/fgi-manpath.csh
@@ -4,5 +4,7 @@
 if ! $?MANPATH then
  setenv MANPATH
 endif
-setenv MANPATH "${MANPATH}:"`man -w` 
+if (`where man` != "") then
+    setenv MANPATH "${MANPATH}:"`man -w`
+endif
 

--- a/files/fgi-manpath.sh
+++ b/files/fgi-manpath.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
 # Set the manpath explicitly, so MANPATH overwrites won't hide system man pages
 
-export MANPATH=$MANPATH:`man -w` 
+if mancmd=$(command -v man); then
+    export MANPATH=$MANPATH:$(${mancmd} -w)
+fi


### PR DESCRIPTION
On a minimal system image, man might not be installed. 'command' and
'where' are shell builtins for bash and tcsh, respectively, so
shouldn't make it noticeably slower.