### PR TITLE
Set LS_COLORS env variable

### DIFF
--- a/files/fgci-colorls.csh
+++ b/files/fgci-colorls.csh
@@ -1,0 +1,21 @@
+# skip everything for non-interactive shells
+if (! $?prompt) exit
+
+# Set LS_COLORS per
+# https://news.sherlock.stanford.edu/posts/when-setting-an-environment-variable-gives-you-a-40-x-speedup
+#setenv LS_COLORS 'ex=00:su=00:sg=00:ca=00:'
+setenv LS_COLORS `echo "$LS_COLORS" |awk -F: 'BEGIN{ORS=":"} \
+{ for (i=1; i < NF; i++) {\
+    if ($i ~ /^ex/) {\
+        print "ex=00"\
+    } else if ($i ~ /^su=/) {\
+        print "su=00"\
+    } else if ($i ~ /^sg=/) {\
+        print "sg=00"\
+    } else if ($i ~ /^ca=/) {\
+        print "ca=00"\
+    } else {\
+        print $i\
+    }\
+ }\
+} END{printf "\n"}'`

--- a/files/fgci-colorls.sh
+++ b/files/fgci-colorls.sh
@@ -1,0 +1,23 @@
+# Skip all for noninteractive shells.
+[ ! -t 0 ] && return
+
+# Set LS_COLORS per
+# https://news.sherlock.stanford.edu/posts/when-setting-an-environment-variable-gives-you-a-40-x-speedup
+# To get coloring on a per filename extension, take the default
+# LS_COLORS, and modify such that ex, su, sg, and ca are 00.
+# export LS_COLORS='ex=00:su=00:sg=00:ca=00:'
+export LS_COLORS=$(echo $LS_COLORS |awk -F: 'BEGIN{ORS=":"}
+{ for (i=1; i < NF; i++) {
+    if ($i ~ /^ex/) {
+        print "ex=00"
+    } else if ($i ~ /^su=/) {
+        print "su=00"
+    } else if ($i ~ /^sg=/) {
+        print "sg=00"
+    } else if ($i ~ /^ca=/) {
+        print "ca=00"
+    } else {
+        print $i
+    }
+ }
+} END{printf "\n"}')


### PR DESCRIPTION
Sets the LS_COLORS environment variable per
https://news.sherlock.stanford.edu/posts/when-setting-an-environment-variable-gives-you-a-40-x-speedup

This avoids a lstat, getxattr, and capget syscall for every file in a
directory.  While it will disable coloring for capabilities,
setuid/setgid and executable files, other file coloring remains.