### PR TITLE
The default script to copy has wrong suffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ By default it copies in:
 Does things like:
  - generate passwordless ssh keys for users
  - changes $MANPATH
- - installs a lmod_log.sh to log lmod module usage
+ - installs a lmod\_log.sh to log lmod module usage
  - changes modules path
 
 # Variables

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,5 +10,5 @@ bash_modules_path: "/cvmfs/fgi.csc.fi/modules/el7/all"
 
 lua_script_copy_all: True # disable by setting copy_all to false and copy_these to []
 lua_script_copy_these:
- - SitePackage.sh
+ - SitePackage.lua
 


### PR DESCRIPTION
additionally fix a missing \ from the documentation.
