### PR TITLE
Set LMOD_FAST_TCL_INTERP=no env variable

### DIFF
--- a/files/lmod.sh
+++ b/files/lmod.sh
@@ -1,4 +1,9 @@
-# Generic env vars for module command which may or may not make one's life easier
+# Generic env vars for module command which may or may not make one's
+# life easier
 
 # This should be default?
 export LMOD_PAGER=/bin/less
+
+# After upgrade to Lmod 8.2.7 need to set this, otherwise ml avail and
+# ml spider fail.
+export LMOD_FAST_TCL_INTERP=no


### PR DESCRIPTION
After upgrade to Lmod 8.2.7 (from 7.8.16) "ml avail" and "ml spider"
commands fail unless this environment variable is set.