### PR TITLE
Allow setting of lmod modulerc file for hiding modules

### DIFF
--- a/templates/lmod.sh
+++ b/templates/lmod.sh
@@ -12,3 +12,8 @@ export LMOD_FAST_TCL_INTERP=no
 # define custom path for adminfile. Used to e.g. deprecate modules
 export LMOD_ADMIN_FILE={{ lmod_admin_file }}
 {% endif %}
+
+{% if lmod_modulerc_file is defined %}
+# define custom path for modulerc file. Used to e.g. hide modules
+export LMOD_MODULERCFILE={{ lmod_modulerc_file }}
+{% endif %}


### PR DESCRIPTION
This PR allows for setting a centrally managed `lmod_modulerc_file`, which can be used to hide old modules without removing them.

See [Lmod's page on hiding modules](https://lmod.readthedocs.io/en/latest/093_modulerc.html) for more information.